### PR TITLE
Use separate animations instead of frames

### DIFF
--- a/Automatic sprite rotation/Cool scene.tscn
+++ b/Automatic sprite rotation/Cool scene.tscn
@@ -307,4 +307,5 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0022893, 0.525261, 0.0268607
 billboard = 2
 frames = SubResource( 57 )
 animation = "idle dir 9"
+playing = true
 script = ExtResource( 3 )

--- a/Automatic sprite rotation/Cool scene.tscn
+++ b/Automatic sprite rotation/Cool scene.tscn
@@ -1,124 +1,284 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=44 format=2]
 
 [ext_resource path="res://Test sprites.png" type="Texture" id=1]
 [ext_resource path="res://orbiting_camera.gd" type="Script" id=2]
 [ext_resource path="res://rotating_sprite.gd" type="Script" id=3]
 [ext_resource path="res://Luigi idle.png" type="Texture" id=4]
 
-[sub_resource type="CubeMesh" id=1]
+[sub_resource type="CubeMesh" id=23]
 
-[sub_resource type="CubeMesh" id=2]
+[sub_resource type="CubeMesh" id=24]
 
-[sub_resource type="AtlasTexture" id=3]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 256, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=4]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 192, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=5]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 128, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=6]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 64, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=7]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 0, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=8]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 960, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=9]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 896, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=10]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 832, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=11]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 768, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=12]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 704, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=13]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 640, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=14]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 576, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=15]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 512, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=16]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 448, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=17]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 384, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=18]
-flags = 3
-atlas = ExtResource( 4 )
-region = Rect2( 320, 0, 64, 64 )
-
-[sub_resource type="AtlasTexture" id=19]
+[sub_resource type="AtlasTexture" id=25]
 flags = 19
 atlas = ExtResource( 1 )
 region = Rect2( 66, 47, 22, 47 )
 
-[sub_resource type="AtlasTexture" id=20]
+[sub_resource type="AtlasTexture" id=26]
 flags = 19
 atlas = ExtResource( 1 )
 region = Rect2( 22, 47, 22, 47 )
 
-[sub_resource type="AtlasTexture" id=21]
+[sub_resource type="AtlasTexture" id=27]
 flags = 19
 atlas = ExtResource( 1 )
 region = Rect2( 0, 47, 22, 47 )
 
-[sub_resource type="AtlasTexture" id=22]
+[sub_resource type="AtlasTexture" id=28]
 flags = 19
 atlas = ExtResource( 1 )
 region = Rect2( 44, 47, 22, 47 )
 
-[sub_resource type="SpriteFrames" id=23]
+[sub_resource type="AtlasTexture" id=33]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 256, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=34]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 192, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=35]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 128, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=36]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 64, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=37]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 0, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=38]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 960, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=39]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 896, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=40]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 832, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=19]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 768, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=20]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 704, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=21]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 640, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=22]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 576, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=41]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 512, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=42]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 448, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=43]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 384, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=44]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 320, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=52]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 0, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=32]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 320, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=30]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 576, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=50]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 256, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=29]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 896, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=46]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 704, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=53]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 192, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=49]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 768, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=31]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 448, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=56]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 640, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=55]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 384, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=47]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 128, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=54]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 512, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=48]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 64, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=45]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 832, 0, 64, 64 )
+
+[sub_resource type="AtlasTexture" id=51]
+flags = 3
+atlas = ExtResource( 4 )
+region = Rect2( 960, 0, 64, 64 )
+
+[sub_resource type="SpriteFrames" id=57]
 animations = [ {
-"frames": [ SubResource( 3 ), SubResource( 4 ), SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ), SubResource( 12 ), SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ) ],
+"frames": [ SubResource( 25 ), SubResource( 26 ), SubResource( 27 ), SubResource( 28 ) ],
+"loop": true,
+"name": "default",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 33 ), SubResource( 34 ), SubResource( 35 ), SubResource( 36 ), SubResource( 37 ), SubResource( 38 ), SubResource( 39 ), SubResource( 40 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 41 ), SubResource( 42 ), SubResource( 43 ), SubResource( 44 ) ],
 "loop": true,
 "name": "More directions",
 "speed": 5.0
 }, {
-"frames": [ SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ) ],
+"frames": [ SubResource( 52 ) ],
 "loop": true,
-"name": "default",
+"name": "idle dir 4",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 32 ) ],
+"loop": true,
+"name": "idle dir 15",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 30 ) ],
+"loop": true,
+"name": "idle dir 11",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 50 ) ],
+"loop": true,
+"name": "idle dir 0",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 29 ) ],
+"loop": true,
+"name": "idle dir 6",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 46 ) ],
+"loop": true,
+"name": "idle dir 9",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 53 ) ],
+"loop": true,
+"name": "idle dir 1",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 49 ) ],
+"loop": true,
+"name": "idle dir 8",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 31 ) ],
+"loop": true,
+"name": "idle dir 13",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 56 ) ],
+"loop": true,
+"name": "idle dir 10",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 55 ) ],
+"loop": true,
+"name": "idle dir 14",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 47 ) ],
+"loop": true,
+"name": "idle dir 2",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 54 ) ],
+"loop": true,
+"name": "idle dir 12",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 48 ) ],
+"loop": true,
+"name": "idle dir 3",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 45 ) ],
+"loop": true,
+"name": "idle dir 7",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 51 ) ],
+"loop": true,
+"name": "idle dir 5",
 "speed": 5.0
 } ]
 
@@ -134,17 +294,17 @@ transform = Transform( 1, 0, 0, 0, 0.995229, 0.0975652, 0, -0.0975652, 0.995229,
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 0.3, 0, 0, 0, 0.245, 0, 0, 0, 0.3, 0, 0, 0 )
-mesh = SubResource( 1 )
+mesh = SubResource( 23 )
 material/0 = null
 
 [node name="MeshInstance" type="MeshInstance" parent="MeshInstance"]
 transform = Transform( 0.170672, 0, 0, 0, 0.153611, 0, 0, 0, 0.1715, 2.00204, 0.095545, 0 )
-mesh = SubResource( 2 )
+mesh = SubResource( 24 )
 material/0 = null
 
 [node name="Luigi" type="AnimatedSprite3D" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0022893, 0.525261, 0.0268607 )
 billboard = 2
-frames = SubResource( 23 )
-animation = "More directions"
+frames = SubResource( 57 )
+animation = "idle dir 9"
 script = ExtResource( 3 )

--- a/Automatic sprite rotation/project.godot
+++ b/Automatic sprite rotation/project.godot
@@ -10,7 +10,6 @@ config_version=4
 
 _global_script_classes=[  ]
 _global_script_class_icons={
-
 }
 
 [application]
@@ -49,5 +48,6 @@ camera_right={
 [rendering]
 
 quality/driver/driver_name="GLES2"
-quality/2d/use_pixel_snap=true
+2d/snapping/use_gpu_pixel_snap=true
 environment/default_environment="res://default_env.tres"
+quality/2d/use_pixel_snap=true

--- a/Automatic sprite rotation/rotating_sprite.gd
+++ b/Automatic sprite rotation/rotating_sprite.gd
@@ -4,6 +4,25 @@
 
 extends AnimatedSprite3D
 
+const IDLE_DIRECTION_ANIMATIONS = [
+	"idle dir 0",
+	"idle dir 1",
+	"idle dir 2",
+	"idle dir 3",
+	"idle dir 4",
+	"idle dir 5",
+	"idle dir 6",
+	"idle dir 7",
+	"idle dir 8",
+	"idle dir 9",
+	"idle dir 10",
+	"idle dir 11",
+	"idle dir 12",
+	"idle dir 13",
+	"idle dir 14",
+	"idle dir 15",
+]
+
 # Private variables
 # The camera that this sprite is rotating based on
 var camera: Camera
@@ -31,8 +50,10 @@ func _process(_delta: float) -> void:
 	relative_angle = wrapf(relative_angle, 0, TAU)
 	
 	# Display the texture that best corresponds to the orientation
-	frame = _round_angle(relative_angle, frames.get_frame_count(animation))
-
+#	var frame = _round_angle(relative_angle, frames.get_frame_count(animation))
+	var frame_index = _round_angle(relative_angle, len(IDLE_DIRECTION_ANIMATIONS))
+	animation = IDLE_DIRECTION_ANIMATIONS[frame_index]
+	
 
 # Gets the orientation of the camera
 # Returns: The camera's orientation, expressed as an angle around the global y 

--- a/Automatic sprite rotation/rotating_sprite.gd
+++ b/Automatic sprite rotation/rotating_sprite.gd
@@ -49,8 +49,7 @@ func _process(_delta: float) -> void:
 			PI/2 - _get_camera_angle()
 	relative_angle = wrapf(relative_angle, 0, TAU)
 	
-	# Display the texture that best corresponds to the orientation
-#	var frame = _round_angle(relative_angle, frames.get_frame_count(animation))
+	# Play the animation that best corresponds to the orientation
 	var frame_index = _round_angle(relative_angle, len(IDLE_DIRECTION_ANIMATIONS))
 	animation = IDLE_DIRECTION_ANIMATIONS[frame_index]
 	


### PR DESCRIPTION
Changes the script a bit to use explicit animations instead of separate frames.

This will make it a lot more scalable when developing this to a larger project.